### PR TITLE
Prevent Action Ranges From Showing While Cursor Moves

### DIFF
--- a/src/TbsTemplate/UI/Pointer.tscn
+++ b/src/TbsTemplate/UI/Pointer.tscn
@@ -117,6 +117,8 @@ Condition = SubResource("Resource_jd7u7")
 
 [node name="OnProcess" parent="ControlState/Root/Active/MouseState" instance=ExtResource("15_n3x6e")]
 
+[node name="OnPhysicsProcessReaction" parent="ControlState/Root/Active/MouseState" instance=ExtResource("16_qorhx")]
+
 [node name="ToFlying" parent="ControlState/Root/Active" node_paths=PackedStringArray("To") instance=ExtResource("11_uxn4c")]
 To = NodePath("../../Flying")
 Event = &"fly"
@@ -161,10 +163,12 @@ texture = ExtResource("16_sbop6")
 [connection signal="StateEntered" from="ControlState/Root/Active/AnalogState" to="." method="OnAnalogStateEntered"]
 [connection signal="Taken" from="ControlState/Root/Active/AnalogState/ToMouse" to="." method="OnToMouseStateTaken"]
 [connection signal="StateUnhandledInput" from="ControlState/Root/Active/AnalogState/OnUnhandledInput" to="." method="OnAnalogStateUnhandledInput"]
+[connection signal="StatePhysicsProcess" from="ControlState/Root/Active/AnalogState/OnPhysicsProcess" to="." method="OnNotDigitalStatePhysicsProcess"]
 [connection signal="StatePhysicsProcess" from="ControlState/Root/Active/AnalogState/OnPhysicsProcess" to="." method="OnAnalogStatePhysicsProcess"]
 [connection signal="StateEntered" from="ControlState/Root/Active/MouseState" to="." method="OnMouseStateEntered"]
 [connection signal="Taken" from="ControlState/Root/Active/MouseState/ToAnalog" to="." method="OnMouseToAnalogTaken"]
 [connection signal="StateProcess" from="ControlState/Root/Active/MouseState/OnProcess" to="." method="OnMouseStateProcess"]
+[connection signal="StatePhysicsProcess" from="ControlState/Root/Active/MouseState/OnPhysicsProcessReaction" to="." method="OnNotDigitalStatePhysicsProcess"]
 [connection signal="StateEntered" from="ControlState/Root/Flying" to="." method="OnFlyingEntered"]
 [connection signal="StateExited" from="ControlState/Root/Flying" to="." method="OnFlyingExited"]
 [connection signal="StateEntered" from="ControlState/Root/Waiting" to="." method="OnWaitingEntered"]


### PR DESCRIPTION
By preventing the `Pointer` from emitting its `PointerStopped` signal during digital control.