### PR TITLE
Fix Unit Army Auto-Assignment

### DIFF
--- a/src/TbsTemplate/Scenes/Level/LevelManager.tscn
+++ b/src/TbsTemplate/Scenes/Level/LevelManager.tscn
@@ -34,7 +34,7 @@
 [ext_resource type="AudioStream" uid="uid://fpepi63ytykk" path="res://test/assets/raw/JDSherbert - Ultimate UI SFX Pack/Free/Mono/wav (HD)/JDSherbert - Ultimate UI SFX Pack - Popup Close - 1.wav" id="32_e2hk2"]
 
 [sub_resource type="FastNoiseLite" id="FastNoiseLite_spp7l"]
-seed = -988620694
+seed = 492842515
 
 [sub_resource type="Resource" id="Resource_umt67"]
 script = ExtResource("24_k1nop")
@@ -457,6 +457,7 @@ stream = ExtResource("31_yh2xe")
 unique_name_in_owner = true
 stream = ExtResource("32_e2hk2")
 
+[connection signal="child_entered_tree" from="." to="." method="OnChildEnteredTree"]
 [connection signal="CellChanged" from="Cursor" to="State/Root/Active/Idle/OnCursorMoved" method="OnCellUpdated"]
 [connection signal="CellChanged" from="Cursor" to="State/Root/Active/UnitSelected/OnCursorMoved" method="OnCellUpdated"]
 [connection signal="CellEntered" from="Cursor" to="State/Root/Active/Idle/OnCursorEnteredCell" method="OnCellUpdated"]


### PR DESCRIPTION
Adds a signal callback to `LevelManager` that, in the editor, connects a newly-added `Army`'s `child_entered_tree` signal to the manager's own callback for that to automatically populate a newly-added `Unit`'s `Grid` property.