### PR TITLE
Fix demo bug with input mode changes

### DIFF
--- a/demo/ContextMenu.cs
+++ b/demo/ContextMenu.cs
@@ -153,29 +153,33 @@ public partial class ContextMenu : PanelContainer
 
     public void OnInputModeChanged(InputMode mode)
     {
-        switch (mode)
+        if (Visible)
         {
-        case InputMode.Mouse:
-            foreach ((_, Button item) in _items)
-                item.MouseFilter = MouseFilterEnum.Stop;
-            if (_selected != NothingSelected)
+            switch (mode)
             {
-                Input.WarpMouse(_items[_options[_selected]].GlobalPosition + _items[_options[_selected]].Size/2);
-                _items[_options[_selected]].ReleaseFocus();
+            case InputMode.Mouse:
+                foreach ((_, Button item) in _items)
+                    item.MouseFilter = MouseFilterEnum.Stop;
+                if (_selected != NothingSelected)
+                {
+                    Input.WarpMouse(_items[_options[_selected]].GlobalPosition + _items[_options[_selected]].Size/2);
+                    _items[_options[_selected]].ReleaseFocus();
+                }
+                break;
+            default:
+                _focus = _hovered == NothingSelected ? (_selected == NothingSelected ? 0 : _selected) : _hovered;
+                foreach ((_, Button item) in _items)
+                    item.MouseFilter = MouseFilterEnum.Ignore;
+                if (Input.IsActionPressed(InputManager.UiAccept))
+                {
+                    GrabFocus(_focus);
+                    _focus = NothingSelected;
+                    // Prevent the focused button from being pressed at the same time as being focused on
+                    GD.Print("handle");
+                    GetViewport().SetInputAsHandled();
+                }
+                break;
             }
-            break;
-        default:
-            _focus = _hovered == NothingSelected ? (_selected == NothingSelected ? 0 : _selected) : _hovered;
-            foreach ((_, Button item) in _items)
-                item.MouseFilter = MouseFilterEnum.Ignore;
-            if (Input.IsActionPressed(InputManager.UiAccept))
-            {
-                GrabFocus(_focus);
-                _focus = NothingSelected;
-                // Prevent the focused button from being pressed at the same time as being focused on
-                GetViewport().SetInputAsHandled();
-            }
-            break;
         }
     }
 

--- a/demo/DemoPauseOverlay.cs
+++ b/demo/DemoPauseOverlay.cs
@@ -36,7 +36,7 @@ public partial class DemoPauseOverlay : Control
     public void Pause()
     {
         GetTree().Paused = true;
-        Visible = true;
+        Visible = Menu.Visible = true;
         if (DeviceManager.Mode != InputMode.Mouse)
             Menu.GrabFocus();
         EmitSignal(SignalName.GamePaused);
@@ -50,9 +50,15 @@ public partial class DemoPauseOverlay : Control
 
     public void Resume()
     {
-        Visible = false;
+        Visible = Menu.Visible = false;
         GetTree().Paused = false;
         EmitSignal(SignalName.GameResumed);
+    }
+
+    public override void _Ready()
+    {
+        base._Ready();
+        Menu.Visible = Visible;
     }
 
     public override void _Input(InputEvent @event)


### PR DESCRIPTION
When changing input modes via select action, the invisible menu would consume the action and prevent the cursor from receiving it